### PR TITLE
Fix the first import try to htmd.config

### DIFF
--- a/moleculekit/molecule.py
+++ b/moleculekit/molecule.py
@@ -1607,7 +1607,7 @@ class Molecule(object):
         retval = None
         if viewer is None:
             try:
-                from moleculekit.config import _config
+                from htmd.config import _config
                 viewer = _config['viewer']
             except:
                 from moleculekit.config import _config


### PR DESCRIPTION
I guess this was the original intention with the try-except, but got messed up in mass-refactoring. Without this fix, HTMD is not working with nglview through `htmd.config`, only through `moleculekit.config` and using `Molecule.view(viewer='webgl')`.

I label as a bug here, even though the bug is only in HTMD. This is somehow urgent and after it's released, should trigger a new HTMD release as well.

N.B. I question myself about the maintainability of these configuration functions cross-packages