### PR TITLE
openbabel update

### DIFF
--- a/moleculekit/tools/atomtyper.py
+++ b/moleculekit/tools/atomtyper.py
@@ -75,7 +75,7 @@ def getPDBQTAtomType(atype, aidx, mol, aromaticNitrogen=False):
 
 def getProperties(mol):
     try:
-        import pybel
+        from openbabel import pybel
     except ImportError:
         raise ImportError('Could not import openbabel. The atomtyper requires this dependency so please install it with `conda install openbabel -c acellera`')
     


### PR DESCRIPTION
openbabel 3.1.1 now support large protein file. From openbable 3.1.1 pybel is included in openbabel (if use openbabel 2.3.x, there would be segmentation fault during reading large protein.mol2 files)