### PR TITLE
Fix printing of newlines in getObenBabelProperties

### DIFF
--- a/moleculekit/tools/obabel_tools/__init__.py
+++ b/moleculekit/tools/obabel_tools/__init__.py
@@ -32,7 +32,8 @@ def getOpenBabelProperties(mol):
             exc.output,
         )
     else:
-        print(output)
+        if output!='\n':
+            print(output)
 
     os.remove(pdbfile)
 


### PR DESCRIPTION
Thanks for this very nice library.
A very annoying (but cosmetic only) thing is that when voxelizing many structures empty lines are printed for each call to this function if openbabel returns nothing. 

This adds a little check for it and only prints the output if is not `\n`