### PR TITLE
Fix bug in XTC read frames

### DIFF
--- a/moleculekit/xtc_utils/src/xtc.cpp
+++ b/moleculekit/xtc_utils/src/xtc.cpp
@@ -526,10 +526,10 @@ void xtc_read_frame(char *filename, float *coords_arr, float *box_arr, float *ti
 		int traj_nframes;
 		double dt;
 		int dstep;
-		int *garbage_natoms;
+		int garbage_natoms;
 
 		//	printf("reading whole file\n" );
-		frames = xtc_read(filename, garbage_natoms, &traj_nframes, &dt, &dstep);
+		frames = xtc_read(filename, &garbage_natoms, &traj_nframes, &dt, &dstep);
 		int xidx, yidx, zidx, aidx;
 		if (frame < traj_nframes)
 		{


### PR DESCRIPTION
When no index files are present, xtc_read_frame tries to read the whole file and then return the selected frame.

The garbage_natoms variable is passed as a null pointer to xtc_read, which then tries to set its value to 0 producing a segfault.

This PR fixes this behavior.