### PR TITLE
chore: move configurations to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,10 @@ namespaces = false
 [build-system]
 requires = ["setuptools", "numpy>=1.18.5", "Cython>=0.29.21", "toml", "versioneer[toml]==0.26"]
 build-backend = "setuptools.build_meta"
+
+[tool.versioneer]
+VCS = "git"
+style = "pep440"
+versionfile_source = "moleculekit/_version.py"
+versionfile_build = "moleculekit/_version.py"
+parentdir_prefix = "moleculekit-"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,9 @@ style = "pep440"
 versionfile_source = "moleculekit/_version.py"
 versionfile_build = "moleculekit/_version.py"
 parentdir_prefix = "moleculekit-"
+
+[tool.pytest.ini_options]
+python_files = "*.py"
+python_classes = "_Test"
+python_functions = "_test*"
+norecursedirs = "test-data"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-python_files = *.py
-python_classes = _Test
-python_functions = _test*
-norecursedirs = test-data

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = moleculekit/_version.py
-versionfile_build = moleculekit/_version.py
-tag_prefix = 
-parentdir_prefix = moleculekit-


### PR DESCRIPTION
This PR aims to minimize the number of configuration files for the project. Instead of a separate `pytest.ini` and `setup.cfg`, we now would have all the configurations within the `pyproject.toml` file leading to a overall minimal code structure.