### PR TITLE
chore: drop redundant lgtm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # MoleculeKit
 
 [![Build Status](https://dev.azure.com/stefdoerr/moleculekit/_apis/build/status/Acellera.moleculekit?branchName=master)](https://dev.azure.com/stefdoerr/moleculekit/_build/latest?definitionId=1&branchName=master)
-[![Language Grade: Python](https://img.shields.io/lgtm/grade/python/g/Acellera/moleculekit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Acellera/moleculekit/context:python)
 [![Conda](https://anaconda.org/acellera/moleculekit/badges/version.svg)](https://anaconda.org/acellera/moleculekit)
 [![codecov](https://codecov.io/gh/Acellera/moleculekit/branch/master/graph/badge.svg)](https://codecov.io/gh/Acellera/moleculekit)
 

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,8 +1,0 @@
-path_classifiers:
-  library:
-    - moleculekit/pdbx  # Define pdbx as external library so it doesn't mess up our statistics on lgtm
-    - moleculekit/lib
-    - moleculekit/test-data
-    - package
-    - doc
-    - ci


### PR DESCRIPTION
This PR aims to remove the redundant LGTM configuration from the repository. It was deprecated a while back [(Source)](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/), It's now a part of Github Code Scanning.

Another evidence is the lgtm grade "no longer available" badge in the README.